### PR TITLE
Allow PPO to turn off advantage normalization

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -14,6 +14,7 @@ Breaking Changes:
 
 New Features:
 ^^^^^^^^^^^^^
+- Allow PPO to turn of advantage normalization (see `PR #61 <https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/pull/61>`_) @vwxyzjn
 
 Bug Fixes:
 ^^^^^^^^^^

--- a/sb3_contrib/ppo_mask/ppo_mask.py
+++ b/sb3_contrib/ppo_mask/ppo_mask.py
@@ -46,6 +46,7 @@ class MaskablePPO(OnPolicyAlgorithm):
         This is a parameter specific to the OpenAI implementation. If None is passed (default),
         no clipping will be done on the value function.
         IMPORTANT: this clipping depends on the reward scaling.
+    :param normalize_advantage: Whether to normalize or not the advantage
     :param ent_coef: Entropy coefficient for the loss calculation
     :param vf_coef: Value function coefficient for the loss calculation
     :param max_grad_norm: The maximum value for the gradient clipping
@@ -76,6 +77,7 @@ class MaskablePPO(OnPolicyAlgorithm):
         gae_lambda: float = 0.95,
         clip_range: Union[float, Schedule] = 0.2,
         clip_range_vf: Union[None, float, Schedule] = None,
+        normalize_advantage: bool = True,
         ent_coef: float = 0.0,
         vf_coef: float = 0.5,
         max_grad_norm: float = 0.5,
@@ -119,6 +121,7 @@ class MaskablePPO(OnPolicyAlgorithm):
         self.n_epochs = n_epochs
         self.clip_range = clip_range
         self.clip_range_vf = clip_range_vf
+        self.normalize_advantage = normalize_advantage
         self.target_kl = target_kl
 
         if _init_setup_model:

--- a/sb3_contrib/ppo_mask/ppo_mask.py
+++ b/sb3_contrib/ppo_mask/ppo_mask.py
@@ -435,7 +435,8 @@ class MaskablePPO(OnPolicyAlgorithm):
                 values = values.flatten()
                 # Normalize advantage
                 advantages = rollout_data.advantages
-                advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
+                if self.normalize_advantage:
+                    advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
 
                 # ratio between old and new policy, should be one at the first iteration
                 ratio = th.exp(log_prob - rollout_data.old_log_prob)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5,6 +5,7 @@ from stable_baselines3.common.vec_env import VecNormalize
 
 from sb3_contrib import ARS, QRDQN, TQC, TRPO, MaskablePPO
 from sb3_contrib.common.vec_env import AsyncEval
+from sb3_contrib.common.envs import InvalidActionEnvDiscrete
 
 
 @pytest.mark.parametrize("ent_coef", ["auto", 0.01, "auto_0.01"])
@@ -146,5 +147,6 @@ def test_offpolicy_multi_env(model_class):
 
 @pytest.mark.parametrize("normalize_advantage", [False, True])
 def test_advantage_normalization(normalize_advantage):
-    model = MaskablePPO("MlpPolicy", "CartPole-v1", n_steps=64, normalize_advantage=normalize_advantage)
+    env = InvalidActionEnvDiscrete(dim=80, n_invalid_actions=60)
+    model = MaskablePPO("MlpPolicy", env, n_steps=64, normalize_advantage=normalize_advantage)
     model.learn(64)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3,7 +3,7 @@ import pytest
 from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.vec_env import VecNormalize
 
-from sb3_contrib import ARS, QRDQN, TQC, TRPO
+from sb3_contrib import ARS, QRDQN, TQC, TRPO, MaskablePPO
 from sb3_contrib.common.vec_env import AsyncEval
 
 
@@ -142,3 +142,9 @@ def test_offpolicy_multi_env(model_class):
         train_freq=5,
     )
     model.learn(total_timesteps=150)
+
+
+@pytest.mark.parametrize("normalize_advantage", [False, True])
+def test_advantage_normalization(model_class, normalize_advantage):
+    model = MaskablePPO("MlpPolicy", "CartPole-v1", n_steps=64, normalize_advantage=normalize_advantage)
+    model.learn(64)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -145,6 +145,6 @@ def test_offpolicy_multi_env(model_class):
 
 
 @pytest.mark.parametrize("normalize_advantage", [False, True])
-def test_advantage_normalization(model_class, normalize_advantage):
+def test_advantage_normalization(normalize_advantage):
     model = MaskablePPO("MlpPolicy", "CartPole-v1", n_steps=64, normalize_advantage=normalize_advantage)
     model.learn(64)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -4,8 +4,8 @@ from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.vec_env import VecNormalize
 
 from sb3_contrib import ARS, QRDQN, TQC, TRPO, MaskablePPO
-from sb3_contrib.common.vec_env import AsyncEval
 from sb3_contrib.common.envs import InvalidActionEnvDiscrete
+from sb3_contrib.common.vec_env import AsyncEval
 
 
 @pytest.mark.parametrize("ent_coef", ["auto", 0.01, "auto_0.01"])


### PR DESCRIPTION
## Description
Allow PPO to turn of advantage normalization. Follow up from https://github.com/DLR-RM/stable-baselines3/pull/763, #60

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] The functionality/performance matches that of the source (**required** for new training algorithms or training-related features).
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have included an example of using the feature (*required for new features*).
- [ ] I have included baseline results (**required** for new training algorithms or training-related features).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly (**required**).
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
