### PR TITLE
Speedup LSTM forward pass

### DIFF
--- a/sb3_contrib/common/recurrent/policies.py
+++ b/sb3_contrib/common/recurrent/policies.py
@@ -148,6 +148,11 @@ class RecurrentActorCriticPolicy(ActorCriticPolicy):
         features_sequence = features.reshape((n_envs, -1, lstm.input_size)).swapaxes(0, 1)
         episode_starts = episode_starts.reshape((n_envs, -1)).swapaxes(0, 1)
 
+        if th.all(episode_starts == 0.0):
+            hidden_eff, lstm_states_eff = lstm(features_sequence, lstm_states)
+            hidden_eff = th.flatten(hidden_eff.transpose(0, 1), start_dim=0, end_dim=1)
+            return hidden_eff, lstm_states_eff
+
         lstm_output = []
         # Iterate over the sequence
         for features, episode_start in zip_strict(features_sequence, episode_starts):

--- a/sb3_contrib/common/recurrent/policies.py
+++ b/sb3_contrib/common/recurrent/policies.py
@@ -148,10 +148,12 @@ class RecurrentActorCriticPolicy(ActorCriticPolicy):
         features_sequence = features.reshape((n_envs, -1, lstm.input_size)).swapaxes(0, 1)
         episode_starts = episode_starts.reshape((n_envs, -1)).swapaxes(0, 1)
 
+        # If we don't have to reset the state in the middle of a sequence
+        # we can avoid the for loop, which speeds up things
         if th.all(episode_starts == 0.0):
-            hidden_eff, lstm_states_eff = lstm(features_sequence, lstm_states)
-            hidden_eff = th.flatten(hidden_eff.transpose(0, 1), start_dim=0, end_dim=1)
-            return hidden_eff, lstm_states_eff
+            lstm_output, lstm_states = lstm(features_sequence, lstm_states)
+            lstm_output = th.flatten(lstm_output.transpose(0, 1), start_dim=0, end_dim=1)
+            return lstm_output, lstm_states
 
         lstm_output = []
         # Iterate over the sequence


### PR DESCRIPTION
If the episode is never restarted, it is not necessary to manually unroll the LSTM to reset the LSTM states. However, one call to the underlying implementation is sufficient. In a small example I was able to achieve a speedup of 3-4 (RTX 3080 Ti).