### PR TITLE
Use higher resolution time_ns() and avoid division by zero

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -15,6 +15,7 @@ New Features:
 
 Bug Fixes:
 ^^^^^^^^^^
+- Fixed division by zero error when computing FPS when a small number of time has elapsed in operating systems with low-precision timers.
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/sb3_contrib/ars/ars.py
+++ b/sb3_contrib/ars/ars.py
@@ -242,8 +242,8 @@ class ARS(BaseAlgorithm):
         """
         Dump information to the logger.
         """
-        time_elapsed = time.time() - self.start_time
-        fps = int((self.num_timesteps - self._num_timesteps_at_start) / (time_elapsed + 1e-8))
+        time_elapsed = max((time.time_ns() - self.start_time) / 1e9, sys.float_info.epsilon)
+        fps = int((self.num_timesteps - self._num_timesteps_at_start) / time_elapsed)
         if len(self.ep_info_buffer) > 0 and len(self.ep_info_buffer[0]) > 0:
             self.logger.record("rollout/ep_rew_mean", safe_mean([ep_info["r"] for ep_info in self.ep_info_buffer]))
             self.logger.record("rollout/ep_len_mean", safe_mean([ep_info["l"] for ep_info in self.ep_info_buffer]))

--- a/sb3_contrib/ars/ars.py
+++ b/sb3_contrib/ars/ars.py
@@ -1,4 +1,5 @@
 import copy
+import sys
 import time
 import warnings
 from functools import partial

--- a/sb3_contrib/ppo_mask/ppo_mask.py
+++ b/sb3_contrib/ppo_mask/ppo_mask.py
@@ -242,7 +242,7 @@ class MaskablePPO(OnPolicyAlgorithm):
         :return:
         """
 
-        self.start_time = time.time()
+        self.start_time = time.time_ns()
         if self.ep_info_buffer is None or reset_num_timesteps:
             # Initialize buffers if they don't exist, or reinitialize if resetting counters
             self.ep_info_buffer = deque(maxlen=100)
@@ -566,13 +566,14 @@ class MaskablePPO(OnPolicyAlgorithm):
 
             # Display training infos
             if log_interval is not None and iteration % log_interval == 0:
-                fps = int((self.num_timesteps - self._num_timesteps_at_start) / (time.time() - self.start_time))
+                time_elapsed = max((time.time_ns() - self.start_time) / 1e9, sys.float_info.epsilon)
+                fps = int((self.num_timesteps - self._num_timesteps_at_start) / time_elapsed)
                 self.logger.record("time/iterations", iteration, exclude="tensorboard")
                 if len(self.ep_info_buffer) > 0 and len(self.ep_info_buffer[0]) > 0:
                     self.logger.record("rollout/ep_rew_mean", safe_mean([ep_info["r"] for ep_info in self.ep_info_buffer]))
                     self.logger.record("rollout/ep_len_mean", safe_mean([ep_info["l"] for ep_info in self.ep_info_buffer]))
                 self.logger.record("time/fps", fps)
-                self.logger.record("time/time_elapsed", int(time.time() - self.start_time), exclude="tensorboard")
+                self.logger.record("time/time_elapsed", int(time_elapsed), exclude="tensorboard")
                 self.logger.record("time/total_timesteps", self.num_timesteps, exclude="tensorboard")
                 self.logger.dump(step=self.num_timesteps)
 

--- a/sb3_contrib/ppo_mask/ppo_mask.py
+++ b/sb3_contrib/ppo_mask/ppo_mask.py
@@ -1,3 +1,4 @@
+import sys
 import time
 from collections import deque
 from typing import Any, Dict, Optional, Tuple, Type, Union


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (e.g. feature name, fix of a bug)-->

## Description
Sister to https://github.com/DLR-RM/stable-baselines3/pull/979

We compute the time elapsed in RL algorithms in order to log both the total time, and the FPS (reciprocal of time elapsed).

This PR changes this time elapsed computation to be a delta of time.time_ns(), which is around 2.3x more precise than time.time() (see [PEP 564](https://peps.python.org/pep-0564/#annex-clocks-resolution-in-python)). Additionally, to avoid the possibility of division by zero when computing FPS, it takes the maximum of the time delta and the float machine epsilon. This replaces a more ad-hoc approach in OffPolicyAlgorithm (not present in OnPolicyAlgorithm, strangely) of adding a fixed 1e-8 to the time elapsed.

## Context
I found that on Windows (lower precision timer than Linux) the computed time elapsed on quick environments for smaller numbers of timesteps would sometimes be 0.0, resulting in a division by zero error. This ended up producing a quite annoying flaky test. I doubt it'd crop up in real use cases where we tend to have total_timesteps larger than 10 (my unit test...), so this is a fairly minor fix, but shouldn't harm anything.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've read the [CONTRIBUTION](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] The functionality/performance matches that of the source (**required** for new training algorithms or training-related features).
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have included an example of using the feature (*required for new features*).
- [ ] I have included baseline results (**required** for new training algorithms or training-related features).
- [ ] I have updated the documentation accordingly.
- [X] I have updated the changelog accordingly (**required**).
- [X] I have reformatted the code using `make format` (**required**)
- [X] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [X] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
