### PR TITLE
Fixed missing verbose parameter passing (#96)

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -18,6 +18,7 @@ Bug Fixes:
 - Fixed the issue of wrongly passing policy arguments when using CnnLstmPolicy or MultiInputLstmPolicy with ``RecurrentPPO`` (@mlodel)
 - Fixed division by zero error when computing FPS when a small number of time has elapsed in operating systems with low-precision timers.
 - Fixed calling child callbacks in MaskableEvalCallback (@CppMaster)
+- Fixed missing verbose parameter passing in the ``MaskableEvalCallback`` constructor (@burakdmb)
 
 
 Deprecations:
@@ -297,4 +298,4 @@ Contributors:
 -------------
 
 @ku2482 @guyk1971 @minhlong94 @ayeright @kronion @glmcdona @cyprienc @sgillen @Gregwar @rnederstigt @qgallouedec
-@mlodel @CppMaster
+@mlodel @CppMaster @burakdmb

--- a/sb3_contrib/ppo_mask/ppo_mask.py
+++ b/sb3_contrib/ppo_mask/ppo_mask.py
@@ -210,6 +210,7 @@ class MaskablePPO(OnPolicyAlgorithm):
                 eval_freq=eval_freq,
                 n_eval_episodes=n_eval_episodes,
                 use_masking=use_masking,
+                verbose=self.verbose,
             )
             callback = CallbackList([callback, eval_callback])
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (e.g. feature name, fix of a bug)-->

## Description
<!--- Describe your changes in detail, including links to any sources for new features -->

According to #96, MaskablePPO does not handle the verbose parameter in MaskableEvalCallback constructor. Therefore I opened a PR to fix this situation. Main issue and PR: https://github.com/DLR-RM/stable-baselines3/issues/1006 and https://github.com/DLR-RM/stable-baselines3/pull/1011

## Context
<!--- Link the related issue here. You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/CONTRIBUTING.md))

This closes #96 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] The functionality/performance matches that of the source (**required** for new training algorithms or training-related features).
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have included an example of using the feature (*required for new features*).
- [ ] I have included baseline results (**required** for new training algorithms or training-related features).
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly (**required**).
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)


<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
