### PR TITLE
Rename the observations variable in the evaluation util to avoid shadowing

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -2,6 +2,7 @@
 
 Changelog
 ==========
+- Renamed environment output observations in ``evaluate_policy`` to prevent shadowing the input observations during callbacks (@npit)
 
 Release 1.8.0 (2023-04-07)
 --------------------------
@@ -418,4 +419,4 @@ Contributors:
 -------------
 
 @ku2482 @guyk1971 @minhlong94 @ayeright @kronion @glmcdona @cyprienc @sgillen @Gregwar @rnederstigt @qgallouedec
-@mlodel @CppMaster @burakdmb @honglu2875 @ZikangXiong @AlexPasqua @jonasreiher
+@mlodel @CppMaster @burakdmb @honglu2875 @ZikangXiong @AlexPasqua @jonasreiher @npit

--- a/sb3_contrib/common/maskable/evaluation.py
+++ b/sb3_contrib/common/maskable/evaluation.py
@@ -103,7 +103,7 @@ def evaluate_policy(
             actions, states = model.predict(
                 observations, state=states, episode_start=episode_starts, deterministic=deterministic
             )
-        observations, rewards, dones, infos = env.step(actions)
+        new_observations, rewards, dones, infos = env.step(actions)
         current_rewards += rewards
         current_lengths += 1
         for i in range(n_envs):
@@ -116,6 +116,7 @@ def evaluate_policy(
 
                 if callback is not None:
                     callback(locals(), globals())
+                observations = new_observations
 
                 if dones[i]:
                     if is_monitor_wrapped:


### PR DESCRIPTION
This is identical to  DLR-RM/stable-baselines3#1288

Note that I can't complete all tests as I can't test

<!--- Provide a general summary of your changes in the Title above (e.g. feature name, fix of a bug)-->
This is a simple renaming. It enables a callback in evaluate_policy to have access to the observation vector that is fed to the environment step function, which is currently shadowed by the output observation.

## Description
<!--- Describe your changes in detail, including links to any sources for new features -->

## Context
<!--- Link the related issue here. You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/CONTRIBUTING.md))

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] The functionality/performance matches that of the source (**required** for new training algorithms or training-related features).
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have included an example of using the feature (*required for new features*).
- [ ] I have included baseline results (**required** for new training algorithms or training-related features).
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly (**required**).
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
