### PR TITLE
Fix crash using SubprocVecEnv with MaskablePPO (#49)

### DIFF
--- a/sb3_contrib/common/maskable/utils.py
+++ b/sb3_contrib/common/maskable/utils.py
@@ -29,8 +29,7 @@ def is_masking_supported(env: GymEnv) -> bool:
 
     if isinstance(env, VecEnv):
         try:
-            # TODO: add VecEnv.has_attr()
-            env.get_attr(EXPECTED_METHOD_NAME)
+            env.env_method(EXPECTED_METHOD_NAME)
             return True
         except AttributeError:
             return False


### PR DESCRIPTION
## Description
This pull request addresses [Issue #49](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/issues/49), which highlights compatibility problems between MaskablePPO and SubProcVecEnv. The solution implements the change proposed by @Maxxxel.

## Context
Closes #49 
- [ x ] I have raised an issue to propose this change ([required](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/CONTRIBUTING.md))

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
- [ x ] I've read the [CONTRIBUTION](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] The functionality/performance matches that of the source (**required** for new training algorithms or training-related features).
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have included an example of using the feature (*required for new features*).
- [ ] I have included baseline results (**required** for new training algorithms or training-related features).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly (**required**).
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
