### PR TITLE
Fix Numerical issues in MaskPPO Training

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -17,6 +17,7 @@ New Features:
 Bug Fixes:
 ^^^^^^^^^^
 - Use the ``FloatSchedule`` and ``LinearSchedule`` classes instead of lambdas in the ARS, PPO, and QRDQN implementations to improve model portability across different operating systems
+- Fixed a bug in the ``MaskableCategoricalDistribution`` and ``MaskableMultiCategoricalDistribution`` classes where the `apply_masking` method was not correctly handling the masks for multi-dimensional action spaces
 
 Deprecations:
 ^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
High-level description: Improve numerical stability by mirroring the logic used by TorchRL, which uses `-inf` instead of a small number and handles masking better.

Details of changes:
1. Use -inf instead of -1e6 as logits when we want to mask
2. In `__init__`, store the original "pristine" logits, then recompute masked logits each time using the original pristine copy in `apply_masking`
3. Remove manual self.probs fiddling since this is handled internally
4. Re-write entropy to ensure that there are no weird NaN issues, mirror logic from torchRL that clamps invalid logits with `min_real` (the minimum possible value of the dtype of the logits), re-normalizes, and then computes entropy only over valid entries.

## Context
closes #81 
- [x] I have raised an issue to propose this change ([required](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/CONTRIBUTING.md))

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] The functionality/performance matches that of the source (**required** for new training algorithms or training-related features).
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have included an example of using the feature (*required for new features*).
- [ ] I have included baseline results (**required** for new training algorithms or training-related features).
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly (**required**).
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)