### PR TITLE
Fix n_updates counting with early stopping in MaskablePPO and RecurrentPPO

### DIFF
--- a/sb3_contrib/ppo_mask/ppo_mask.py
+++ b/sb3_contrib/ppo_mask/ppo_mask.py
@@ -407,10 +407,10 @@ class MaskablePPO(OnPolicyAlgorithm):
                 th.nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
                 self.policy.optimizer.step()
 
+            self._n_updates += 1
             if not continue_training:
                 break
 
-        self._n_updates += self.n_epochs
         explained_var = explained_variance(self.rollout_buffer.values.flatten(), self.rollout_buffer.returns.flatten())
 
         # Logs

--- a/sb3_contrib/ppo_recurrent/ppo_recurrent.py
+++ b/sb3_contrib/ppo_recurrent/ppo_recurrent.py
@@ -416,10 +416,10 @@ class RecurrentPPO(OnPolicyAlgorithm):
                 th.nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
                 self.policy.optimizer.step()
 
+            self._n_updates += 1
             if not continue_training:
                 break
 
-        self._n_updates += self.n_epochs
         explained_var = explained_variance(self.rollout_buffer.values.flatten(), self.rollout_buffer.returns.flatten())
 
         # Logs


### PR DESCRIPTION
## Description
This PR fixes incorrect `n_updates` counting in both `MaskablePPO` and `RecurrentPPO` when early stopping is triggered due to the `target_kl` threshold.

**The Problem**: 
- Previously, `n_updates` was always incremented by the full `n_epochs` value (default: 10) regardless of actual epochs completed
- When `target_kl` triggered early stopping (e.g., at epoch 5), `n_updates` would still increment by 10 instead of 5
- This caused inaccurate learning rate scheduling, progress tracking, and inconsistent behavior with regular PPO

**The Solution**:
- Move `n_updates` increment inside the epoch loop to count only completed epochs
- Each epoch now increments `n_updates` by 1, matching the behavior of base PPO
- Early stopping now correctly reflects actual training progress

**Files Changed**:
- `sb3_contrib/ppo_mask/ppo_mask.py`
- `sb3_contrib/ppo_recurrent/ppo_recurrent.py`

## Testing
The fix has been verified with:
- Reproduction cases showing the bug in both algorithms
- Logs demonstrating correct counting after the fix
- Early stopping at various steps (0-7) to validate accurate incrementing

## Impact
- [X] Accurate learning rate scheduling
- [X] Proper training progress tracking  
- [X] Consistent behavior with Stable-Baselines3 PPO
- [X] No breaking changes - only affects counting logic